### PR TITLE
Updated README with corrected #to_s

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Time::DATE_FORMATS[:military] = Stamp.strftime_format("23:59")
 To use your formats:
 
 ```ruby
-Date.today.to_s_(:short)  #=> "Sat Jul 16"
+Date.today.to_s(:short)  #=> "Sat Jul 16"
 Time.now.to_s(:military)  #=> "15:35"
 ```
 


### PR DESCRIPTION
Under the Rails integration section you have

```
 Date.today.to_s_(:short)  #=> "Sat Jul 16"
```

this commit corrects it

```
Date.today.to_s(:short)  #=> "Sat Jul 16"
```
