### PR TITLE
for older rubies, use older capabara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 source "https://rubygems.org"
 
 gemspec
+
+# cap cucumber version for older rubies
+if RUBY_VERSION < "1.9.3"
+  gem "cucumber", ">=0.2.2"
+end
+


### PR DESCRIPTION
Looks like the build is failing.

It is having trouble resolving capabara in older versions of ruby.
I can't seem to get a version of 1.8.7 or 1.9.2 installed on my local box, so I'm kinda winging this. But it has worked on older projects, and travis will tell us the errors of our ways soon enough.

If you use Gemnasium, it will balk. Let me know and I can introduce another method for that. (it is uglier, but will work)

Let me know if you would prefer to remove 1.8.7/1.9.2