### PR TITLE
add support for active support TimeWithZone

### DIFF
--- a/lib/stamp.rb
+++ b/lib/stamp.rb
@@ -48,3 +48,8 @@ end
 
 Date.send(:include, ::Stamp)
 Time.send(:include, ::Stamp)
+begin
+  require 'active_support/time'
+  ActiveSupport::TimeWithZone.send(:include, ::Stamp)
+rescue LoadError
+end

--- a/stamp.gemspec
+++ b/stamp.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'activesupport'
 end

--- a/test/emitters/delegate_test.rb
+++ b/test/emitters/delegate_test.rb
@@ -5,6 +5,13 @@ class DelegateTest < Minitest::Test
     assert_equal 'UTC', e.format(Time.now.utc)
   end
 
+  def test_format_zone_current
+    e = Stamp::Emitters::Delegate::ZONE
+
+    assert_equal 'MST', e.format(Time.current.in_time_zone('MST'))
+  rescue NoMethodError
+  end
+
   def test_format_year
     e = Stamp::Emitters::Delegate::YEAR
 


### PR DESCRIPTION
not thrilled about including active support. Seems active support specifics could sneak into other areas of the code.

not sure if it really matters

fixes #29
